### PR TITLE
Add answer file for "formatting" in Rust by Example

### DIFF
--- a/Programing Language/Rust/formatting.rs
+++ b/Programing Language/Rust/formatting.rs
@@ -1,0 +1,58 @@
+// Answer file for the activity section on `1.2.3. Formatting`
+// https://doc.rust-lang.org/rust-by-example/hello/print/fmt.html
+
+use std::fmt::{self, Formatter, Display};
+
+struct City {
+    name: &'static str,
+    // Latitude
+    lat: f32,
+    // Longitude
+    lon: f32,
+}
+
+impl Display for City {
+    // `f` is a buffer, and this method must write the formatted string into it
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let lat_c = if self.lat >= 0.0 { 'N' } else { 'S' };
+        let lon_c = if self.lon >= 0.0 { 'E' } else { 'W' };
+
+        // `write!` is like `format!`, but it will write the formatted string
+        // into a buffer (the first argument)
+        write!(f, "{}: {:.3}°{} {:.3}°{}",
+               self.name, self.lat.abs(), lat_c, self.lon.abs(), lon_c)
+    }
+}
+
+struct Color {
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
+// ANSWER = Use Sign https://doc.rust-lang.org/std/fmt/#sign0 
+// and UpperHex formatting trait https://doc.rust-lang.org/std/fmt/trait.UpperHex.html
+impl Display for Color {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "RGB ({r}, {g}, {b}) 0x{r:02X}{g:02X}{b:02X}",
+               r = self.red, g = self.green, b = self.blue)
+               // NOTE = Named parameters are optional, but improves readability
+    }
+}
+
+fn main() {
+    for city in [
+        City { name: "Dublin", lat: 53.347778, lon: -6.259722 },
+        City { name: "Oslo", lat: 59.95, lon: 10.75 },
+        City { name: "Vancouver", lat: 49.25, lon: -123.1 },
+    ].iter() {
+        println!("{}", *city);
+    }
+    for color in [
+        Color { red: 128, green: 255, blue: 90 },
+        Color { red: 0, green: 3, blue: 254 },
+        Color { red: 0, green: 0, blue: 0 },
+    ].iter() {
+        println!("{}", *color);
+    }
+}


### PR DESCRIPTION
Answer file for the activity section on `1.2.3. Formatting`

https://doc.rust-lang.org/rust-by-example/hello/print/fmt.html